### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/IniTest.php
+++ b/tests/IniTest.php
@@ -16,14 +16,14 @@ final class IniTest extends TestCase
 
 
     /** @inheritDoc */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ini = new Ini();
     }
 
 
     /** @inheritDoc */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->ini->cleanup();
     }

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -17,7 +17,7 @@ final class StateTest extends TestCase
 
 
     /** @inheritDoc */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->state = new State();
     }


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp` and `protected function tearDown` methods.